### PR TITLE
Added loading skeleton for the images 

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -26,15 +26,20 @@ export default function Gallery() {
             key={scribble._id}
             className="p-2 py-3 md:w-80 lg:w-90 max-w-full"
           >
-            <img
-              loading="lazy"
-              className="cursor-pointer w-full h-full"
-              width={0}
-              height={0}
-              src={scribble.result}
-              alt="A piece of art"
-              onClick={() => handleScribbleClick(scribble.result)}
-            />
+            {!scribble.result || scribble.result.length === 0 ? (
+              <div className="w-full h-full bg-gray-300 animate-pulse" />
+            ) : (
+              <img
+                loading="lazy"
+                className="cursor-pointer w-full h-full"
+                width={0}
+                height={0}
+                src={scribble.result}
+                alt="A piece of art"
+                onClick={() => handleScribbleClick(scribble.result)}
+              />
+            )}
+
             <div className="text-center">{scribble.prompt}</div>
           </div>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -188,17 +188,22 @@ export default function Home() {
             {sortedQuery.slice(0, 6).map((scribble) => (
               <div
                 className="p-1 w-30 max-w-full md:h-80 md:w-80 xl:w-90"
-                key={scribble.id}
+                key={scribble._id}
               >
-                <img
-                  src={scribble.result}
-                  alt="Artwork is loading..."
-                  width={0}
-                  height={0}
-                  className="cursor-pointer w-full h-full"
-                  title="Click to expand"
-                  onClick={() => handleScribbleClick(scribble.result)}
-                />
+                {!scribble.result || scribble.result.length === 0 ? (
+                  <div className="w-full h-full bg-gray-300 animate-pulse" />
+                ) : (
+                  <img
+                    loading="lazy"
+                    src={scribble.result}
+                    alt="Artwork is loading..."
+                    width={0}
+                    height={0}
+                    className="cursor-pointer w-full h-full"
+                    title="Click to expand"
+                    onClick={() => handleScribbleClick(scribble.result)}
+                  />
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
- Added a loading skeleton for when the image is loading both for the home page and the gallery page 
- The loading skeleton is simple (grey background with a pulsating animation) 
- I tried different ways to do this by keeping track of the image loading using onLoad(), and keeping track of the _creationTime to show a skeleton for loading images and to show images that have been generated after a certain amount of time (such as one minute or 30 seconds), but those approaches did not work 
- The final approach and the best approach I believe is to just keep track of the result url and display based on that using a ternary operator. If the image is loading, the result url will be undefined, so I will show a skeleton. If the result url is not undefined, I will show the image. This resolves all my previous issues as it shows a skeleton for images that are loading, there is no need to keep track of the _creationTime, and previous loaded images are always shown. 
- Another fix was to use _id instead of id 
- Here are some images showing the image loading and the skeleton before and after 

Before: 
![Before adding skeleton](https://i.imgur.com/qPznONw.png) 

After: 
![After adding skeleton](https://i.imgur.com/8X13V5u.png) 